### PR TITLE
Minor readme clarification: 'Beacon' -> 'Location'

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Location.requestAlwaysAuthorization();
 
 ## Methods
 
-To access the methods, you need import the `react-native-location` module. This is done through `var Beacons = require('react-native-location')`.
+To access the methods, you need import the `react-native-location` module. This is done through `var Location = require('react-native-location')`.
 
 ### Location.requestWhenInUseAuthorization
 ```javascript


### PR DESCRIPTION
Hey, 

Just a typo fix in the readme:

-Variable name for react-native-location module is `Location` everywhere except for this one place (where it's `Beacon`).  I'm assuming it used to be `Beacon` and was later changed to `Location`, a more fitting name.