### PR TITLE
Fix exporting RNLocation

### DIFF
--- a/RNLocation.ios.js
+++ b/RNLocation.ios.js
@@ -4,6 +4,6 @@
  */
 'use strict';
 
-var NativeRNLocation = require('NativeModules').RNLocation;
+var NativeModules = require('react-native').NativeModules
 
-module.exports = NativeRNLocation;
+module.exports = NativeModules.RNLocation;


### PR DESCRIPTION
As per the [Native Modules](https://facebook.github.io/react-native/docs/native-modules-ios.html) guide this is the current API for exporting a module.