### PR TITLE
Expose a method to set allowsBackgroundLocationUpdates

### DIFF
--- a/RNLocation.m
+++ b/RNLocation.m
@@ -65,6 +65,11 @@ RCT_EXPORT_METHOD(setDistanceFilter:(double) distance)
     self.locationManager.distanceFilter = distance;
 }
 
+RCT_EXPORT_METHOD(setAllowsBackgroundLocationUpdates:(BOOL) enabled)
+{
+    self.locationManager.allowsBackgroundLocationUpdates = enabled;
+}
+
 RCT_EXPORT_METHOD(startMonitoringSignificantLocationChanges)
 {
     NSLog(@"react-native-location: startMonitoringSignificantLocationChanges");


### PR DESCRIPTION
Enabling this appears to be necessary in order to have location updates fire when the app is backgrounded, when linking against iOS 9. From the [docs](https://developer.apple.com/library/ios/documentation/CoreLocation/Reference/CLLocationManager_Class/#//apple_ref/occ/instp/CLLocationManager/allowsBackgroundLocationUpdates):

> Apps that want to receive location updates when suspended must include the UIBackgroundModes key (with the location value) in their app’s Info.plist file and set the value of this property to YES. The presence of the UIBackgroundModes key with the location value is required for background updates; you use this property to enable and disable the behavior based on your app’s behavior. For example, you might set the value to YES only after the user enables features in your app where background updates are needed.
>
> When the value of this property is NO, apps receive location updates normally while running in either the foreground or background based on its current authorization. Updates stop only when the app is suspended, thereby preventing the app from being woken up to handle those events.
>
> The default value of this property is NO. Setting the value to YES but omitting the UIBackgroundModes key and location value in your app’s Info.plist file is a programmer error.