### PR TITLE
react-native dev-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-location",
   "version": "0.14.2",
-  "dependencies": {
+  "devDependencies": {
     "react-native": "^0.14"
   },
   "repository": {


### PR DESCRIPTION
Hey guys,

I put react-native into dev-dependencies to be able to use your package in my own project without the hassle of resolve duplicate paths. E.g. react-native is once in my own node_modules directory and in the sub-node_modules directory of react-native-location.

This may not be an issue in node >= 4, but iojs does not resolve packages in a flat directory structure.

Cheers