### PR TITLE
Update headers to refer to react namespace for react-native 0.40

### DIFF
--- a/ios/RNLocation.h
+++ b/ios/RNLocation.h
@@ -1,4 +1,4 @@
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface RNLocation : NSObject <RCTBridgeModule>
 

--- a/ios/RNLocation.m
+++ b/ios/RNLocation.m
@@ -1,8 +1,8 @@
 #import <CoreLocation/CoreLocation.h>
 
-#import "RCTBridge.h"
-#import "RCTConvert.h"
-#import "RCTEventDispatcher.h"
+#import <React/RCTBridge.h>
+#import <React/RCTConvert.h>
+#import <React/RCTEventDispatcher.h>
 
 #import "RNLocation.h"
 


### PR DESCRIPTION
Update react headers to make react-native 0.40 work