### PR TITLE
fix: TypeError in getLatestLocation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -156,7 +156,7 @@ export const getLatestLocation = (
 
       // Sort the locations with the most recent first
       const sortedLocations = locations.sort(
-        (a, b) => b.timestamp.getTime() - a.timestamp.getTime()
+        (a, b) => b.timestamp - a.timestamp
       );
 
       // Unsubscribe from future updates

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,7 +62,7 @@ export interface Location {
    * The time that the device was at this location.
    * @platform android ios
    */
-  timestamp: Date;
+  timestamp: number;
   /**
    * The latitude of the location.
    * @platform android ios


### PR DESCRIPTION
If `subscribeToLocationUpdates` returns a list of `Locations` the sort
  callback throws a type error because `location.timestamp` is a number
  type rather than a Date type.  Updated the Location interface type
  and sort callback accordingly.

I'm not super comfortable with typescript yet, and I can't test on IOS, so I hope this doesn't break anything :)

Connects #54 