### PR TITLE
Use context for location provider if activity is not available

### DIFF
--- a/android/src/main/java/com/github/reactnativecommunity/location/RNPlayServicesLocationProvider.java
+++ b/android/src/main/java/com/github/reactnativecommunity/location/RNPlayServicesLocationProvider.java
@@ -46,8 +46,13 @@ public class RNPlayServicesLocationProvider implements RNLocationProvider {
 
     public RNPlayServicesLocationProvider(Activity activity, ReactApplicationContext context) {
         this.context = context;
-        locationProvider = LocationServices.getFusedLocationProviderClient(activity);
-        locationSettingsClient = LocationServices.getSettingsClient(activity);
+        if (activity != null) {
+            locationProvider = LocationServices.getFusedLocationProviderClient(activity);
+            locationSettingsClient = LocationServices.getSettingsClient(activity);
+        } else {
+            locationProvider = LocationServices.getFusedLocationProviderClient(context);
+            locationSettingsClient = LocationServices.getSettingsClient(context);
+        }
     }
 
     // Public interface


### PR DESCRIPTION
The current activity may be null when the location provider is created, in which case we can use the React application context instead. Alternatively we could wait for the activity to become non-null, but that would add some more complexity.

Resolves: #56 