### PR TITLE
Return a promise for configuring

### DIFF
--- a/android/src/main/java/com/github/reactnativecommunity/location/RNStandardLocationProvider.java
+++ b/android/src/main/java/com/github/reactnativecommunity/location/RNStandardLocationProvider.java
@@ -33,6 +33,7 @@ public class RNStandardLocationProvider implements RNLocationProvider {
         if (watchedProvider != null) {
             setupListening();
         }
+        promise.resolve(null);
     }
 
     @Override

--- a/example/App.js
+++ b/example/App.js
@@ -24,9 +24,7 @@ export default class App extends React.PureComponent {
   componentWillMount() {
     RNLocation.configure({
       distanceFilter: 5.0
-    });
-
-    RNLocation.requestPermission({
+    }).then(() => RNLocation.requestPermission({
       ios: "whenInUse",
       android: {
         detail: "fine",
@@ -37,7 +35,7 @@ export default class App extends React.PureComponent {
           buttonNegative: "Cancel"
         }
       }
-    }).then(granted => {
+    })).then(granted => {
       if (granted) {
         this._startUpdatingLocation();
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,10 +65,10 @@ _configureHelpers(nativeInterface, eventEmitter);
  * You can call `configure` multiple times at it will only change the setting which you pass to it. For example, if you only want to change `activityType`, you can call `configure` with just that property present.
  *
  * @param {ConfigureOptions} options The configuration options.
- * @returns {void}
+ * @returns {Promise<void>} A Promise which resolves when the configuration is completed.
  */
-export const configure = (options: ConfigureOptions): void => {
-  nativeInterface.configure(options);
+export const configure = (options: ConfigureOptions): Promise<void> => {
+  return nativeInterface.configure(options);
 };
 
 /**


### PR DESCRIPTION
The native code returns a promise, which has been ignored by the JS
code. Return it and update the example usage.

Resolves: https://github.com/timfpark/react-native-location/issues/57