### PR TITLE
Fixed Typescript error

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export type LocationActivityType =
  * The location provider to use for Android.
  * @platform android
  */
-export type AndroidProvider = "auto" | "fused" | "builtin";
+export type AndroidProvider = "auto" | "playServices" | "standard";
 /**
  * The accuracy of the location responses for Android.
  * @platform android


### PR DESCRIPTION
Hello :)

this PR addresses a problem in AndroidProvider type definition. As stated in READ.ME it should be `"auto" | "playServices" | "standard"` and not `"auto" | "fused" | "builtin"`