### PR TITLE
Don't crash when starting resolution if activity is null

### DIFF
--- a/android/src/main/java/com/github/reactnativecommunity/location/RNPlayServicesLocationProvider.java
+++ b/android/src/main/java/com/github/reactnativecommunity/location/RNPlayServicesLocationProvider.java
@@ -161,7 +161,7 @@ public class RNPlayServicesLocationProvider implements RNLocationProvider {
         task.addOnFailureListener(new OnFailureListener() {
             @Override
             public void onFailure(@NonNull Exception e) {
-                if (e instanceof ResolvableApiException) {
+                if (e instanceof ResolvableApiException && activity != null) {
                     // Location settings are not satisfied, but this can be fixed
                     // by showing the user a dialog.
                     try {


### PR DESCRIPTION
I'm getting a few of those crashes in production. Not sure how to repro and why activity is null in this case but this seems better than crashing.