### PR TITLE
Change from using Android support libraries (which are deprecated) to Androidx

### DIFF
--- a/android/src/main/java/com/github/reactnativecommunity/location/RNPlayServicesLocationProvider.java
+++ b/android/src/main/java/com/github/reactnativecommunity/location/RNPlayServicesLocationProvider.java
@@ -6,8 +6,9 @@ import android.content.Intent;
 import android.content.IntentSender;
 import android.content.pm.PackageManager;
 import android.location.Location;
-import android.support.annotation.NonNull;
-import android.support.v4.app.ActivityCompat;
+import androidx.annotation.NonNull;
+import androidx.core.app.ActivityCompat;
+
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;

--- a/android/src/main/java/com/github/reactnativecommunity/location/Utils.java
+++ b/android/src/main/java/com/github/reactnativecommunity/location/Utils.java
@@ -2,7 +2,7 @@ package com.github.reactnativecommunity.location;
 
 import android.location.Location;
 import android.os.Build;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;


### PR DESCRIPTION
According to Android documentation, [Support Libraries](https://developer.android.com/topic/libraries/support-library/) have been deprecated in favor of [Androidx](https://developer.android.com/jetpack/androidx/).

I used the ["Migrating to Androidx"](https://developer.android.com/jetpack/androidx/migrate) page and [Android Support to Androidx class mappings](https://developer.android.com/jetpack/androidx/migrate/class-mappings) to change the imported classes to the non-deprecated versions. These libraries are drop-in replaceable.

Tested on project with software versions:

react-native-location: 6.13.4
Node: 10.19.0
npm: 6.13.4
react: 16.9.0
react-native: 0.62.0
Android 9, API level 28
SDK platform-tools: 29.0.6
