### PR TITLE
Migrate android.support annotations and classes to AndroidX

### DIFF
--- a/android/src/main/java/com/github/reactnativecommunity/location/RNPlayServicesLocationProvider.java
+++ b/android/src/main/java/com/github/reactnativecommunity/location/RNPlayServicesLocationProvider.java
@@ -6,8 +6,8 @@ import android.content.Intent;
 import android.content.IntentSender;
 import android.content.pm.PackageManager;
 import android.location.Location;
-import android.support.annotation.NonNull;
-import android.support.v4.app.ActivityCompat;
+import androidx.annotation.NonNull;
+import androidx.core.app.ActivityCompat;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;

--- a/android/src/main/java/com/github/reactnativecommunity/location/Utils.java
+++ b/android/src/main/java/com/github/reactnativecommunity/location/Utils.java
@@ -2,7 +2,7 @@ package com.github.reactnativecommunity.location;
 
 import android.location.Location;
 import android.os.Build;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;


### PR DESCRIPTION
**Summary**
This PR updates the Android implementation to replace deprecated android.support.* imports with their androidx.* equivalents. This ensures compatibility with modern React Native projects, which use AndroidX by default.

**Changes Made**

In RNPlayServicesLocationProvider.java:

Replaced android.support.annotation.NonNull with androidx.annotation.NonNull

Replaced android.support.v4.app.ActivityCompat with androidx.core.app.ActivityCompat

In Utils.java:

Replaced android.support.annotation.Nullable with androidx.annotation.Nullable

**Why This Change Is Needed**

The Android Support Library is deprecated and no longer maintained.

Newer React Native versions and Android builds require AndroidX.

Without this change, projects using AndroidX fail to compile when depending on this library.

**Impact**

No functional changes — only import updates.

Fully backward-compatible with AndroidX-enabled projects.